### PR TITLE
gulp4 ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # gulp-require-tasks changelog
 
+## Version 1.1.0
+(18 Aug 2016)
+
+- *include* and *exclude* options added
+
 ## Version 1.0.3
 (16 Mar 2016)
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ const gulpRequireTasks = require('gulp-require-tasks');
 
 // Invoke the module with options.
 gulpRequireTasks({
-  
+
   // Specify path to your tasks directory.
   path: process.cwd() + '/gulp-tasks' // This is default!
-  
+
   // Additionally pass any options to it from the table below.
   // ...
-  
+
 });
 
 // Or, use minimal invokation possible with all options set to defaults.
@@ -78,6 +78,8 @@ require('gulp-require-tasks')({
 | Property     | Default Value     | Description
 | ------------ | ----------------- | --------------------------------------------------------
 | path         | `'./gulp-tasks'`  | Path to directory from which to load your tasks modules
+| include      | `null`            | Whitelisting (either via RegExp or function) allows you to specify that only certain files be loaded.
+| exclude      | `null`            | Blacklisting (either via RegExp or function) allows you to specify that all but certain files should be loaded.
 | separator    | `:`               | Task name separator, your tasks would be named, e.g. `foo:bar:baz` for `./tasks/foo/bar/baz.js`
 | arguments    | `[]`              | Additional arguments to pass to your task function
 | passGulp     | `true`            | Whether to pass Gulp instance as a first argument to your task function

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function gulpRequireTasks (options) {
   options = _.extend({}, DEFAULT_OPTIONS, options);
 
   const gulp = options.gulp || require('gulp');
+  const gulp4 = !!gulp.series;
 
   // Recursively visiting all modules in the specified directory
   // and registering Gulp tasks.
@@ -35,14 +36,28 @@ function gulpRequireTasks (options) {
    * @param {string} modulePath
    */
   function moduleVisitor (module, modulePath) {
+    var args = [taskNameFromPath(modulePath)];
+    var module = normalizeModule(module, gulp4);
+    var batchName;
 
-    module = normalizeModule(module);
+    if (gulp4) {
+      if (module.dep) {
+        // Can get dep: [] which is equal to dep: { series: [] }
+        // or dep: { parallel: [] }
+        if (_.isPlainObject(module.dep)) {
+          batchName = module.dep.parallel ? 'parallel' : 'series';
+          args.push(gulp[batchName].apply(gulp, module.dep[batchName]));
+        } else {
+          args.push(gulp.series.apply(gulp, module.dep));
+        }
+      } else {
+        args.push(module.nativeTask || taskFunction);
+      }
+    } else {
+      args.push(module.dep, module.nativeTask || taskFunction);
+    }
 
-    gulp.task(
-      taskNameFromPath(modulePath),
-      module.dep,
-      module.nativeTask || taskFunction
-    );
+    gulp.task.apply(gulp, args);
 
     /**
      * Wrapper around user task function.
@@ -102,9 +117,11 @@ function removeExtension (path) {
  *
  * @returns {object}
  */
-function normalizeModule (module) {
+function normalizeModule (module, gulp4) {
   if ('function' === typeof module) {
-    return {
+    return gulp4 ? {
+      fn: module
+    } : {
       fn: module,
       dep: []
     };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = gulpRequireTasks;
 
 const DEFAULT_OPTIONS = {
   path: process.cwd() + '/gulp-tasks',
+  include: null,
+  exclude: null,
   separator: ':',
   arguments: [],
   passGulp: true,
@@ -26,6 +28,9 @@ function gulpRequireTasks (options) {
   // and registering Gulp tasks.
   requireDirectory(module, options.path, {
     visit: moduleVisitor
+  }, {
+    include: options.include,
+    exclude: options.exclude
   });
 
   /**

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ module.exports = gulpRequireTasks;
 
 const DEFAULT_OPTIONS = {
   path: process.cwd() + '/gulp-tasks',
+  include: null,
+  exclude: null,
   separator: ':',
   arguments: [],
   passGulp: true,
@@ -25,7 +27,9 @@ function gulpRequireTasks (options) {
   // Recursively visiting all modules in the specified directory
   // and registering Gulp tasks.
   requireDirectory(module, options.path, {
-    visit: moduleVisitor
+    visit: moduleVisitor,
+    include: options.include,
+    exclude: options.exclude
   });
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-require-tasks",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Loads Gulp tasks from the multiple individual files",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-require-tasks",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Loads Gulp tasks from the multiple individual files",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Теперь работает с Галпом 4.
Для последовательного выполнения

```
module.exports = {
    dep: {
        series: ['styleguide:gen', 'styleguide:appstyles']
    }
}
```

Либо просто

```
module.exports = {
    dep: ['styleguide:gen', 'styleguide:appstyles']
}
```

Для параллельного выполнения

```
module.exports = {
    dep: {
        parallel: ['styleguide:gen', 'styleguide:appstyles']
    }
}
```
