### PR TITLE
Remove Lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,11 @@ const DEFAULT_OPTIONS = {
 
 const path = require('path');
 const requireDirectory = require('require-directory');
-const _ = require('lodash');
 
 
 function gulpRequireTasks (options) {
 
-  options = _.extend({}, DEFAULT_OPTIONS, options);
+  options = Object.assign({}, DEFAULT_OPTIONS, options);
 
   const gulp = options.gulp || require('gulp');
 
@@ -55,7 +54,7 @@ function gulpRequireTasks (options) {
      */
     function taskFunction (callback) {
       if ('function' === typeof module.fn) {
-        var arguments = _.clone(options.arguments);
+        var arguments = Array.from(options.arguments);
         if (options.passGulp) {
           arguments.unshift(gulp);
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/betsol/gulp-require-tasks#readme",
   "dependencies": {
     "gulp": "^3.9.1",
-    "lodash": "^4.6.1",
     "require-directory": "^2.1.1"
   }
 }


### PR DESCRIPTION
Hi Slava,

According to the version of the last Node.js LTS (6.10.3) and its support of ECMAScript®, I think we could remove the dependency to Lodash and use the native equivalents :smiley:

Hope this pull request contributes to your Gulp plugin,
Xavier.